### PR TITLE
Fix ambiguous array truth value in histogram fit overlay

### DIFF
--- a/main.py
+++ b/main.py
@@ -351,7 +351,9 @@ def update_hist(hoverData, clickData, xscale, mode,
                     fig.add_scatter(x=x, y=curves["ln"], mode="lines", name=f"{method}: bulk", line=dict(width=1, dash="dot"))
                     fig.add_scatter(x=x, y=curves["pareto"], mode="lines", name=f"{method}: tail", line=dict(width=1, dash="dash"))
                 else:
-                    y = curves.get("fit") or curves.get("mix")
+                    y = curves.get("fit")
+                    if y is None:
+                        y = curves.get("mix")
                     if y is not None:
                         fig.add_scatter(x=x, y=y, mode="lines", name=method, line=dict(width=2))
 


### PR DESCRIPTION
## Summary
- avoid ValueError from evaluating numpy arrays in boolean context

## Testing
- `pytest`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_689e12e3c530832d9fd16afff07fe351