### PR TITLE
Add scripts for saving and loading fitted magnification models

### DIFF
--- a/fit_psi.py
+++ b/fit_psi.py
@@ -1,0 +1,65 @@
+"""Fit cached histograms and save the resulting parameters.
+
+This script loads histogram data prepared by ``data_prep.py`` and fits the
+mixture model implemented in :mod:`mu_generator`.  The fitted parameters are
+written to an ``.npz`` file that can later be consumed by
+``load_psi_model.py`` to build an interpolator.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+from mu_generator import load_interpolated, fit_single
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Run the fitting pipeline and persist results."""
+
+    parser = argparse.ArgumentParser(description="Fit histograms and save psi parameters")
+    parser.add_argument(
+        "--cache-dir",
+        default="data_cache",
+        help="directory containing histogram cache and samples.csv",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="optional limit on the number of histograms to fit",
+    )
+    parser.add_argument(
+        "--out",
+        default="psi_fits.npz",
+        help="output filename for the fitted parameters",
+    )
+    args = parser.parse_args(argv)
+
+    grid, items = load_interpolated(args.cache_dir)
+    df = pd.read_csv(os.path.join(args.cache_dir, "samples.csv")).set_index("rid")
+
+    psi_list: List[np.ndarray] = []
+    params: List[np.ndarray] = []
+    for item in items[: args.limit]:
+        rid = item["rid"]
+        if rid not in df.index:
+            continue
+        psi_list.append(fit_single(grid, item["cnt"], item["N"]))
+        params.append(df.loc[rid, ["kappa", "gamma", "s"]].to_numpy())
+
+    if not psi_list:
+        raise RuntimeError("no histograms fitted; check cache directory")
+
+    psi_arr = np.vstack(psi_list)
+    params_arr = np.vstack(params)
+    np.savez(args.out, psi=psi_arr, params=params_arr)
+    print(f"wrote {len(psi_arr)} fits to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/load_psi_model.py
+++ b/load_psi_model.py
@@ -1,0 +1,70 @@
+"""Load saved psi fits and provide distribution utilities.
+
+The ``fit_psi.py`` script saves mixture model parameters for many histogram
+realizations.  This module reads those fits, constructs the
+:class:`mu_generator.PsiModel` interpolator and offers a small command line
+interface for evaluating or sampling ``p(mu | kappa, gamma, s)``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Iterable, List
+
+import numpy as np
+import pandas as pd
+
+from mu_generator import (
+    PsiModel,
+    analytic_cdf_mu,
+    analytic_p_mu,
+    build_psi_model,
+    p_mu_given_eta,
+    sample_mu,
+)
+
+
+def load_model(fits_file: str) -> PsiModel:
+    """Load ``psi`` fits from ``fits_file`` and build a :class:`PsiModel`."""
+    data = np.load(fits_file)
+    psi = data["psi"]
+    params = data["params"]
+    df = pd.DataFrame(params, columns=["kappa", "gamma", "s"])
+    model = build_psi_model(df, list(psi))
+    return model
+
+
+def main(argv: List[str] | None = None) -> None:
+    """Small CLI for sampling or evaluating the PDF."""
+
+    parser = argparse.ArgumentParser(description="Use saved psi fits")
+    parser.add_argument("--fits", default="psi_fits.npz", help="file produced by fit_psi.py")
+    parser.add_argument("--kappa", type=float, required=True, help="kappa value")
+    parser.add_argument("--gamma", type=float, required=True, help="gamma value")
+    parser.add_argument("--s", type=float, required=True, help="s value")
+    parser.add_argument(
+        "--mu", type=float, default=None, help="if given, evaluate PDF at this mu value"
+    )
+    parser.add_argument("--size", type=int, default=0, help="number of samples to draw")
+    parser.add_argument("--seed", type=int, default=None, help="random seed for sampling")
+    args = parser.parse_args(argv)
+
+    model = load_model(args.fits)
+
+    if args.mu is not None:
+        val = p_mu_given_eta(np.array([args.mu]), args.kappa, args.gamma, args.s, model)
+        print(val[0])
+    elif args.size > 0:
+        rng = np.random.default_rng(args.seed)
+        samples = sample_mu(args.kappa, args.gamma, args.s, model, args.size, rng)
+        for mu in samples:
+            print(mu)
+    else:
+        parser.error("either --mu or --size must be specified")
+
+
+__all__ = ["load_model", "analytic_p_mu", "analytic_cdf_mu", "p_mu_given_eta", "sample_mu", "PsiModel"]
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `fit_psi.py` to fit cached histograms and store resulting psi parameters
- add `load_psi_model.py` to load saved fits, build interpolator and provide CLI for evaluation or sampling

## Testing
- `python -m py_compile fit_psi.py load_psi_model.py`
- `python fit_psi.py --limit 5 --out psi_test.npz`
- `python load_psi_model.py --fits psi_test.npz --kappa 0.5 --gamma 0.5 --s 0.5 --size 2 --seed 42`


------
https://chatgpt.com/codex/tasks/task_e_689f555e536c832d9ff5abb4d35f1718