### PR TITLE
Add Stan conditional mixture model and fitting utilities

### DIFF
--- a/end2end/stan_model.py
+++ b/end2end/stan_model.py
@@ -1,0 +1,165 @@
+"""Stan-based conditional analytic distribution fitting.
+
+This module provides utilities to prepare data for the Stan model
+``pmu_conditional.stan`` and to fit it using :mod:`cmdstanpy`.  It reuses the
+histogram loading and basis feature helpers from :mod:`end2end.model` but
+delegates optimisation to Stan.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Tuple
+
+import numpy as np
+from cmdstanpy import CmdStanModel, CmdStanMLE
+from scipy.special import gamma
+
+from .model import basis_features, load_dataset
+
+
+# ---------------------------------------------------------------------------
+# Data preparation
+# ---------------------------------------------------------------------------
+
+def prepare_stan_data(
+    cache_dir: str,
+    basis_fn: Callable[[np.ndarray], np.ndarray] = basis_features,
+    *,
+    limit: int | None = None,
+    K: int = 2,
+    sigma_min: float = 0.05,
+    lambda_ent: float = 1e-3,
+    lambda_tail: float = 1e-3,
+    eq_weight: int = 1,
+) -> Tuple[Dict[str, np.ndarray], Dict[str, np.ndarray]]:
+    """Load cached histograms and assemble a Stan ``data`` dictionary.
+
+    Parameters
+    ----------
+    cache_dir:
+        Directory containing the preprocessed histograms produced by
+        ``data_prep.py``.
+    basis_fn:
+        Callable mapping ``η=(κ, γ, s)`` to feature vectors.
+    limit:
+        Optional maximum number of histogram files to load.
+    K:
+        Number of log-normal mixture components in the Stan model.
+    sigma_min, lambda_ent, lambda_tail, eq_weight:
+        Hyper-parameters passed straight to Stan.
+
+    Returns
+    -------
+    stan_data, aux
+        ``stan_data`` is a dictionary compatible with ``pmu_conditional.stan``;
+        ``aux`` contains feature normalisation statistics that must be supplied
+        when predicting new ``η`` values.
+    """
+
+    data = load_dataset(cache_dir, limit=limit)
+    if not data:
+        raise RuntimeError("no data loaded; ensure cache directory is correct")
+
+    # check common log-mu grid
+    y0 = data[0]["y"]
+    if not all(np.allclose(d["y"], y0) for d in data):
+        raise ValueError("all histograms must share the same log-mu grid")
+    mu = np.exp(y0)
+    dmu = np.exp(y0 + 0.5 * (y0[1] - y0[0])) - np.exp(y0 - 0.5 * (y0[1] - y0[0]))
+
+    cnt = np.vstack([d["cnt"] for d in data]).astype(int)
+    Ntot = np.array([d["N"] for d in data])
+
+    feats = np.vstack([basis_fn(d["eta"]) for d in data])
+    mean = feats.mean(axis=0)
+    std = feats.std(axis=0)
+    B = (feats - mean) / (std + 1e-12)
+
+    stan_data: Dict[str, np.ndarray] = {
+        "I": cnt.shape[0],
+        "J": cnt.shape[1],
+        "mu": mu,
+        "dmu": dmu,
+        "cnt": cnt,
+        "Ntot": Ntot,
+        "P": B.shape[1],
+        "B": B,
+        "K": K,
+        "sigma_min": sigma_min,
+        "lambda_ent": lambda_ent,
+        "lambda_tail": lambda_tail,
+        "eq_weight": eq_weight,
+    }
+    aux = {"feat_mean": mean, "feat_std": std, "sigma_min": sigma_min, "K": K}
+    return stan_data, aux
+
+
+# ---------------------------------------------------------------------------
+# Fitting and prediction
+# ---------------------------------------------------------------------------
+
+def fit_model(stan_data: Dict[str, np.ndarray], *, stan_file: str = "pmu_conditional.stan", **kwargs) -> Tuple[CmdStanModel, CmdStanMLE]:
+    """Compile and fit the Stan model returning the model and MAP estimate."""
+
+    model = CmdStanModel(stan_file=stan_file)
+    fit = model.optimize(data=stan_data, **kwargs)
+    return model, fit
+
+
+def _lognormal_pdf(mu: np.ndarray, m: float, s: float) -> np.ndarray:
+    return 1.0 / (mu * s * np.sqrt(2.0 * np.pi)) * np.exp(-0.5 * ((np.log(mu) - m) / s) ** 2)
+
+
+def _tail_pdf(mu: np.ndarray, alpha: float, mu0: float) -> np.ndarray:
+    return (mu0**alpha / gamma(alpha)) * mu ** (-(alpha + 1.0)) * np.exp(-mu0 / mu)
+
+
+@dataclass
+class StanState:
+    fit: CmdStanMLE
+    aux: Dict[str, np.ndarray]
+    basis_fn: Callable[[np.ndarray], np.ndarray] = basis_features
+
+
+def pdf_mu(eta: np.ndarray, mu: np.ndarray, state: StanState) -> np.ndarray:
+    """Evaluate ``p(μ|η)`` using fitted Stan parameters."""
+
+    fit = state.fit
+    aux = state.aux
+    K = int(aux["K"])
+    sigma_min = float(aux["sigma_min"])
+    phi = state.basis_fn(eta)
+    phi = (phi - aux["feat_mean"]) / (aux["feat_std"] + 1e-12)
+
+    beta_m1 = fit.stan_variable("beta_m1")
+    beta_m_diff = fit.stan_variable("beta_m_diff")
+    beta_logsig = fit.stan_variable("beta_logsig")
+    beta_w = fit.stan_variable("beta_w")
+    beta_alpha = fit.stan_variable("beta_alpha")
+    beta_mu0 = fit.stan_variable("beta_mu0")
+
+    m1 = phi @ beta_m1
+    means = [m1]
+    if K > 1:
+        deltas = phi @ beta_m_diff
+        deltas = np.log1p(np.exp(deltas))
+        for d in deltas:
+            means.append(means[-1] + d)
+    means = np.array(means)
+
+    sig_raw = phi @ beta_logsig
+    sigmas = sigma_min + np.log1p(np.exp(sig_raw))
+
+    logits = phi @ beta_w
+    w = np.exp(logits - logits.max())
+    w = w / w.sum()
+
+    alpha = 1.0 + np.log1p(np.exp(phi @ beta_alpha))
+    mu0 = np.log1p(np.exp(phi @ beta_mu0))
+
+    pdf = np.zeros_like(mu)
+    for k in range(K):
+        pdf += w[k] * _lognormal_pdf(mu, means[k], sigmas[k])
+    pdf += w[K] * _tail_pdf(mu, alpha, mu0)
+    return pdf
+

--- a/pmu_conditional.stan
+++ b/pmu_conditional.stan
@@ -1,0 +1,102 @@
+functions {
+  real tail_lpdf(real x, real alpha, real mu0) {
+    return alpha * log(mu0) - lgamma(alpha) - (alpha + 1) * log(x) - mu0 / x;
+  }
+  real lognormal_pdf(real x, real m, real s) {
+    return exp(lognormal_lpdf(x | m, s));
+  }
+  real tail_pdf(real x, real alpha, real mu0) {
+    return exp(tail_lpdf(x, alpha, mu0));
+  }
+}
+
+data {
+  int<lower=1> I;               // number of histogram conditions
+  int<lower=1> J;               // number of mu bins
+  vector[J] mu;                 // mu grid
+  vector[J] dmu;                // bin widths in mu
+  int<lower=0> cnt[I, J];       // histogram counts
+  vector<lower=0>[I] Ntot;      // total counts per condition
+  int<lower=1> P;               // basis dimension
+  matrix[I, P] B;               // basis matrix
+  int<lower=1> K;               // number of lognormal components
+  real<lower=0> sigma_min;      // lower bound for sigma
+  real<lower=0> lambda_ent;     // negative entropy regulariser
+  real<lower=0> lambda_tail;    // weak prior on tail exponent
+  int<lower=0,upper=1> eq_weight; // weight datasets equally
+}
+
+parameters {
+  vector[P] beta_m1;                // base mean
+  matrix[P, K - 1] beta_m_diff;     // mean differences
+  matrix[P, K] beta_logsig;         // log sigma params
+  matrix[P, K + 1] beta_w;          // weight logits (incl. tail)
+  vector[P] beta_alpha;             // tail exponent
+  vector[P] beta_mu0;               // tail scale
+}
+
+transformed parameters {
+  matrix[I, K] m;                  // means
+  matrix[I, K] s;                  // sigmas
+  matrix[I, K + 1] w;              // weights incl. tail
+  vector[I] alpha;
+  vector[I] mu0;
+
+  for (i in 1:I) {
+    row_vector[P] Bi = B[i];
+    // means with ordering
+    real m1 = Bi * beta_m1;
+    m[i,1] = m1;
+    for (k in 2:K) {
+      real diff = Bi * beta_m_diff[, k - 1];
+      m[i,k] = m[i,k-1] + log1p_exp(diff); // softplus difference
+    }
+    // sigmas
+    for (k in 1:K) {
+      real sr = Bi * beta_logsig[, k];
+      s[i,k] = sigma_min + log1p_exp(sr);
+    }
+    // weights
+    row_vector[K + 1] logits = Bi * beta_w;
+    w[i] = softmax(logits)';
+    // tail params
+    alpha[i] = 1 + log1p_exp(Bi * beta_alpha);
+    mu0[i] = log1p_exp(Bi * beta_mu0);
+  }
+}
+
+model {
+  // priors on coefficients
+  to_vector(beta_m1) ~ normal(0, 1);
+  to_vector(beta_m_diff) ~ normal(0, 1);
+  to_vector(beta_logsig) ~ normal(0, 1);
+  to_vector(beta_w) ~ normal(0, 1);
+  beta_alpha ~ normal(0, 1);
+  beta_mu0 ~ normal(0, 1);
+
+  for (i in 1:I) {
+    real wgt = eq_weight ? inv(Ntot[i]) : 1.0;
+    // negative entropy regularisation
+    target += -lambda_ent * dot_product(w[i], log(w[i] + 1e-12));
+    // weak prior on tail exponent
+    target += -lambda_tail * (alpha[i] - 1);
+    for (j in 1:J) {
+      real pdf = 0;
+      for (k in 1:K) {
+        pdf += w[i,k] * lognormal_pdf(mu[j], m[i,k], s[i,k]);
+      }
+      pdf += w[i,K+1] * tail_pdf(mu[j], alpha[i], mu0[i]);
+      real rate = fmax(1e-12, Ntot[i] * pdf * dmu[j]);
+      target += wgt * poisson_lpmf(cnt[i,j] | rate);
+    }
+  }
+}
+
+generated quantities {
+  // entropy for monitoring
+  vector[I] mix_entropy;
+  for (i in 1:I) {
+    mix_entropy[i] = -dot_product(w[i], log(w[i] + 1e-12));
+  }
+}
+


### PR DESCRIPTION
## Summary
- Add `pmu_conditional.stan` implementing a conditional lognormal-plus-tail mixture with basis mapping and regularisation.
- Provide `end2end/stan_model.py` utilities to prepare histogram data, fit the Stan model via cmdstanpy and evaluate pdfs for new parameters.

## Testing
- `python -m py_compile end2end/stan_model.py`


------
https://chatgpt.com/codex/tasks/task_e_689f7e2cfb04832d97a87cfa26146321